### PR TITLE
fix QuickStartStackMaker updates

### DIFF
--- a/templates/lambda.template.yaml
+++ b/templates/lambda.template.yaml
@@ -113,7 +113,7 @@ Resources:
               cf_client = get_client("cloudformation", e, c)
               rp = e['ResourceProperties']
               try:
-                get_client("cloudformation", e, c).update_stack(
+                response = cf_client.update_stack(
                     StackName=e["PhysicalResourceId"],
                     TemplateBody=rp['TemplateBody'],
                     Parameters=get_cfn_parameters(e),


### PR DESCRIPTION
*Fixes #7 *

*Description of changes:*
- The QuickStartStackMaker Lambda function now correctly retrieves the CloudFormation response in stack updates.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
