### PR TITLE
Upgrade deprecated runtime nodejs8.10

### DIFF
--- a/sample-project/sample.yaml
+++ b/sample-project/sample.yaml
@@ -17,7 +17,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: api/handler.sample
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       Timeout: 10
       MemorySize: 128
       Environment:


### PR DESCRIPTION
CloudFormation templates in quickstart-trek10-serverless-enterprise-cicd have been found to include a [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (nodejs8.10). The affected templates have been updated to a supported runtime (nodejs10.x).

Please note, **this pull request has been generated by a bot**; please check the base branch and files changed before merging.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.